### PR TITLE
Enhancements to make npm-extractor more useful in generic context

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "tar-pack": "^3.1.3",
     "usage": "^0.7.1",
     "uuid": "^2.0.1",
-    "webpack": "^1.12.14"
+    "webpack": "^1.12.14",
+    "webpack-merge": "^0.14.1"
   },
   "devDependencies": {
     "memory-fs": "^0.3.0"

--- a/server/cleaner.js
+++ b/server/cleaner.js
@@ -1,22 +1,21 @@
-var memoryFs = require('./memoryFs');
 var utils = require('./utils');
 var path = require('path');
 var vendorsQueue = require('./vendorsQueue');
 
-module.exports = function (queueId) {
+module.exports = function (options) {
   return function (bundle) {
     var timeout = utils.isProduction() ? 1000 * 60 * 5 : 1000 * 10;
     setTimeout(function () {
       Object.keys(bundle.entries).forEach(function (entry) {
-        memoryFs.fs.rmdirSync(path.join('/', 'queues', queueId, 'node_modules', entry));
+        options.targetFs.rmdirSync(path.join('/', 'queues', options.queueId, 'node_modules', entry));
       });
-      memoryFs.fs.rmdirSync(path.join('/', 'bundles', bundle.name));
-      memoryFs.fs.rmdirSync(path.join('/', 'queues', queueId, 'node_modules'));
-      memoryFs.fs.rmdirSync(path.join('/', 'queues', queueId));
+      options.targetFs.rmdirSync(path.join('/', 'bundles', bundle.name));
+      options.targetFs.rmdirSync(path.join('/', 'queues', options.queueId, 'node_modules'));
+      options.targetFs.rmdirSync(path.join('/', 'queues', options.queueId));
       vendorsQueue.remove(bundle.name);
       console.log('Removed entries ' + Object.keys(bundle.entries) + ' and ' + bundle.name);
     }, timeout);
 
     return bundle;
-  }
+  };
 };

--- a/server/extract.js
+++ b/server/extract.js
@@ -45,8 +45,14 @@ module.exports = function (req, res) {
     });
   }))
   .then(resolveEntries(packages))
-  .then(vendorsBundler.compile(queueId))
-  .then(cleaner(queueId))
+  .then(vendorsBundler.compile({
+      queueId: queueId,
+      targetFs: memoryFs.fs
+  }))
+  .then(cleaner({
+      queueId: queueId,
+      targetFs: memoryFs.fs
+  }))
   .then(function (bundle) {
     vendorsQueue.update(queueId, {
       name: bundle.name,

--- a/server/extractor.js
+++ b/server/extractor.js
@@ -1,8 +1,6 @@
 var request = require('request');
 var tar = require('tar')
 var zlib = require('zlib');
-var MemoryFs = require('memory-fs');
-var mfs = new MemoryFs();
 var fs = require('fs');
 var path = require('path');
 var rreaddir = require('recursive-readdir');

--- a/server/vendorsBundler.js
+++ b/server/vendorsBundler.js
@@ -4,9 +4,13 @@ var memoryFs = require('./memoryFs');
 var path = require('path');
 var utils = require('./utils');
 var vendorEntries = require('./vendorEntries');
+var merge = require('webpack-merge');
 
 module.exports = {
-  compile: function (queueId) {
+  compile: function (queueId, options) {
+    
+    options = options || {};
+
     return function (bundle) {
       console.log('Bundling ', bundle.entries);
       return new Promise(function (resolve, reject) {
@@ -26,7 +30,7 @@ module.exports = {
           );
         }, []);
 
-        var vendorsCompiler = webpack({
+        var defaultWebpackConfig = {
           context: '/',
           entry: {
             vendors: vendors
@@ -61,7 +65,14 @@ module.exports = {
              loader: 'json'
            }]
          }
-        });
+        };
+
+        var webpackConfig = merge.smart(
+            options.webpack || {},
+            defaultWebpackConfig
+        );
+
+        var vendorsCompiler = webpack(webpackConfig);
         vendorsCompiler.outputFileSystem = memoryFs.fs;
         vendorsCompiler.inputFileSystem = memoryFs.fs;
         vendorsCompiler.resolvers.normal.fileSystem = memoryFs.fs;


### PR DESCRIPTION
- Make it possible to provide pass webpack options to vendorsBundler, which are [smartly merged](https://www.npmjs.com/package/webpack-merge#smart-merging-of-loaders) with the default options.
- server/extract.js provided targetFs to extractor but vendorsBundler and cleaner relied on a global singleton making this option not so useful. The change consistently passes targetfs option to inner modules, removing their dependency on the singleton.
